### PR TITLE
relation issues

### DIFF
--- a/models.js
+++ b/models.js
@@ -134,11 +134,15 @@ const Pet = pawDb.define('pets', {
     },
     zip: {
         type: Sequelize.INTEGER,
-        allownull: false
+        allowNull: false
     },
     house_size: {
         type: Sequelize.STRING,
-        allownull: false
+        allowNull: false
+    },
+    animal_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false
     }
 })
 
@@ -181,10 +185,8 @@ Pet.belongsToMany(Volunteer, {
 Volunteer.belongsTo(Pet);
 
 
-Adopter.belongsToMany(Pet, {
-    through: 'adopters_to_pets_xref',
-    foreignKey: 'adopter_id'})
-Pet.belongsTo(Adopter);
+
+Adopter.belongsTo(Pet)
 
 
 AuthUser.beforeCreate(async (user,options) => {

--- a/scripts/seedDb.js
+++ b/scripts/seedDb.js
@@ -38,7 +38,8 @@ const seedDb = async () => {
       city:'nyc',
       state: 'ny',
       zip: 12345,
-      house_size_sqft: '1234'
+      house_size: '1234',
+      animal_id: 99
     })
 
   } catch (e) { 


### PR DESCRIPTION
each adopter is assigned an animal_id attribute when selecting the pet they inquire.
It works as a static attribute for now - which is not ideal.

Ideal solution is setting the relationship which the table has an entry for..

const twoPossibleSolutions = {

one(bad): make animal_id an array and push each animal_id to the array 'where: email == 
                  this.state.email' (this leaves the potential error of i.d's existing within the array that no 
                  longer correlate with the pet object),

two(v good): set the relationship by passing down the 'animal_id' and running a findbyPK() under pets 
                      and setting that relationship to that adopter object??

};

**thinking I need to set relationship through an api call**